### PR TITLE
Adding a simpler wrapper

### DIFF
--- a/modules/lib_vnr/src/inference/wrapper_simple.cpp
+++ b/modules/lib_vnr/src/inference/wrapper_simple.cpp
@@ -1,0 +1,27 @@
+
+#include "wrapper_simple.h"
+
+void vnr_simple_init(vnr_ctx_t *ctx){
+    // vnr input state init
+    vnr_input_state_init(&ctx->vnr_input_state);
+    // vnr feature state init
+    vnr_feature_state_init(&ctx->vnr_feature_state);
+    // vnr inference init
+    int32_t err = vnr_inference_init();
+    assert(err == 0);
+}
+
+void vnr_simple_compute(vnr_ctx_t *ctx){
+    static complex_s32_t DWORD_ALIGNED input_frame[VNR_FD_FRAME_LENGTH];
+    static bfp_complex_s32_t X;
+    static bfp_s32_t feature_patch;
+    static float_s32_t vnr_output_s32;
+    static float vnr_output_float = 0.0f;
+
+    vnr_form_input_frame(&ctx->vnr_input_state, &X, input_frame, ctx->new_frame);
+    vnr_extract_features(&ctx->vnr_feature_state, &feature_patch, ctx->feature_patch_data, &X);
+    vnr_inference(&vnr_output_s32, &feature_patch);
+    vnr_output_float = ldexpf((float)vnr_output_s32.mant, vnr_output_s32.exp);
+    ctx->vnr_output_s32 = vnr_output_s32;
+    ctx->vnr_output_float32 = vnr_output_float;
+}

--- a/modules/lib_vnr/src/inference/wrapper_simple.h
+++ b/modules/lib_vnr/src/inference/wrapper_simple.h
@@ -1,0 +1,32 @@
+#pragma once
+#include <stdint.h>
+
+#include "xmath/xmath.h"
+
+#include "vnr_features_api.h"
+#include "vnr_inference_api.h"
+
+typedef struct{
+    // States
+    vnr_input_state_t vnr_input_state;
+    vnr_feature_state_t vnr_feature_state;
+    // Input
+    int32_t new_frame[VNR_FRAME_ADVANCE];
+    int32_t feature_patch_data[VNR_PATCH_WIDTH*VNR_MEL_FILTERS];
+    // Output
+    float_s32_t vnr_output_s32;
+    float vnr_output_float32;
+} vnr_ctx_t;
+
+// Note: user should use ctx->new_frame to provide new input frame data
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void vnr_simple_init(vnr_ctx_t *ctx);
+void vnr_simple_compute(vnr_ctx_t *ctx);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
```C
typedef struct{
    // States
    vnr_input_state_t vnr_input_state;
    vnr_feature_state_t vnr_feature_state;
    // Input
    int32_t new_frame[VNR_FRAME_ADVANCE];
    int32_t feature_patch_data[VNR_PATCH_WIDTH*VNR_MEL_FILTERS];
    // Output
    float_s32_t vnr_output_s32;
    float vnr_output_float32;
} vnr_ctx_t;
```

```C
vnr_ctx_t vnr_ctx;
vnr_simple_init(&vnr_ctx);
chan_in_buf_word(c_vnr, (uint32_t*)vnr_ctx.new_frame, VNR_SAMPLES);
vnr_simple_compute(&vnr_ctx);
float_s32_t outs32 =  vnr_ctx.vnr_output_s32;
float out = vnr_ctx.vnr_output_float32;
```